### PR TITLE
[15.0][FIX] calendar_document_popup: precommit and tests

### DIFF
--- a/calendar_document_popup/README.rst
+++ b/calendar_document_popup/README.rst
@@ -1,6 +1,6 @@
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
-	:target: http://www.gnu.org/licenses/agpl
-	:alt: License: AGPL-3
+    :target: http://www.gnu.org/licenses/agpl
+    :alt: License: AGPL-3
 
 =======================
 Calendar Document Popup

--- a/calendar_document_popup/models/calendar_event.py
+++ b/calendar_document_popup/models/calendar_event.py
@@ -2,19 +2,18 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
-from odoo.http import request
 
 
 class Meeting(models.Model):
     _inherit = "calendar.event"
 
     documents_link = fields.Char(
-        compute="get_documents_link", string="Documents", store=True
+        compute="_compute_documents_link", string="Documents", store=True
     )
 
     @api.depends("res_model", "res_id")
-    def get_documents_link(self):
-        url_base = request.env["ir.config_parameter"].get_param("web.base.url")
+    def _compute_documents_link(self):
+        url_base = self.env["ir.config_parameter"].get_param("web.base.url")
         for record in self:
             res = ""
             if record.res_model and record.res_id:


### PR DESCRIPTION
**Summary**: This PR fixes the precommit and unit tests errors of the calendar_document_popup module. The purpose is to merge this PR: https://github.com/sygel-technology/sy-calendar/pull/4

**Test Issue**: Although the module does not have unit tests, they fail initializing the test enviroment due to the request.env issue (see https://github.com/sygel-technology/sy-calendar/actions/runs/17939672619/job/51013065811?pr=4), and it has been fixed in this PR


============= **Detailed description** =============

**Reason for the fix:** CI/CD was introduced in Sygel’s GitHub repository more than a year ago. However, some modules were created before CI/CD was implemented. These legacy modules fail the pre-commit hooks and the automated tests executed by GitHub when creating a new PR, which prevents any new module from passing the CI/CD checks. In this specific case, the calendar_document_popup module is blocking the merge of this PR: #4 

**Previous behavior:** The calendar_document_popup module exists in this repository and works functionally, but it does not comply with pre-commit rules or unit tests. 

**Why it has been changed:** The CI/CD errors in the calendar_document_popup module prevent merging PR #4. The issues identified in that PR are: 
- Incorrect README formatting. 
- A compute method not following the compute* naming convention. The method has been renamed, along with its references throughout the module.
- Use of request.env instead of self.env for ORM queries within a model (outside of a controller). This error was raised during the initialization of the test enviroment (in spite of the fact that this module has no tests), and has been fixed with this change.
